### PR TITLE
Matplot without an X server

### DIFF
--- a/output/hazardCurvesNRML2Png.py
+++ b/output/hazardCurvesNRML2Png.py
@@ -12,6 +12,8 @@ import sys
 import argparse
 from lxml import etree
 import numpy
+import matplotlib as mpl
+mpl.use('Agg')
 import matplotlib.pyplot as plt
 import pylab
 

--- a/output/lossCurvesNRML2Png.py
+++ b/output/lossCurvesNRML2Png.py
@@ -12,6 +12,8 @@ import sys
 import argparse
 from lxml import etree
 import numpy
+import matplotlib as mpl
+mpl.use('Agg')
 import matplotlib.pyplot as plt
 
 xmlNRML = '{http://openquake.org/xmlns/nrml/0.3}'


### PR DESCRIPTION
This is a very little change to allow to run hazardCurvesNRML2Png without an X server.
